### PR TITLE
Switch to the public libsignal-protocol-rust for libsignal-ffi

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,17 +18,12 @@ jobs:
 
       - name: Check out libsignal-ffi
         uses: actions/checkout@v2
-        with:
-          path: libsignal-ffi
 
-      - name: Check out libsignal-protocol-rust
-        uses: actions/checkout@v2
-        with:
-          repository: signalapp/libsignal-protocol-rust
-          path: libsignal-protocol-rust
+      - name: Configure git to use HTTPS
+        run: git config --global url."https://github.com".insteadOf ssh://git@github.com
 
       - name: Build libsignal-ffi
-        run: make -C libsignal-ffi
+        run: make
 
 # TODO: In the future, we should also run tests for our clients,
 # to make sure a change doesn't break them (at least not unexpectedly).
@@ -42,19 +37,12 @@ jobs:
     steps:
       - name: Check out libsignal-ffi
         uses: actions/checkout@v2
-        with:
-          path: libsignal-ffi
 
-      - name: Check out libsignal-protocol-rust
-        uses: actions/checkout@v2
-        with:
-          repository: signalapp/libsignal-protocol-rust
-          path: libsignal-protocol-rust
+      - name: Configure git to use HTTPS
+        run: git config --global url."https://github.com".insteadOf ssh://git@github.com
 
       - name: Rustfmt check
         run: cargo fmt -- --check
-        working-directory: libsignal-ffi
 
       - name: Clippy
         run: cargo clippy
-        working-directory: libsignal-ffi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,7 @@ name = "signal_ffi"
 crate-type = ["dylib"]
 
 [dependencies]
-libsignal-protocol-rust = { path = "../libsignal-protocol-rust" }
-#libsignal-protocol-rust = { git = "ssh://git@github.com/signalapp/libsignal-protocol-rust.git" }
+libsignal-protocol-rust = { git = "ssh://git@github.com/signalapp/libsignal-protocol-rust.git" }
 rand = "0.7.3"
 libc = "0.2"
 num-traits = "0.2"


### PR DESCRIPTION
To set up relative paths for a particular checkout of libsignal-ffi, run the following series of commands:

```
echo 'Cargo.toml filter=local-deps' >> .git/info/attributes
git config filter.local-deps.smudge \
  'sed -E -e "s|{ *git *= *\"ssh://git@github\.com/signalapp/(.+)\.git\" *}|{ path = \"../\1\" } # local-deps: &|"'
git config filter.local-deps.clean \
  'sed -E -e "s|{.+} # local-deps: {(.+)}|{\1}|"'
```

This will replace any dependencies on GitHub repositories under the signalapp organization with path dependencies in the parent folder. The checkout must be named the same as the repo on GitHub.
