### PR TITLE
Build as "cdylib", and set the right install name on Apple platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [lib]
 name = "signal_ffi"
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 libsignal-protocol-rust = { git = "ssh://git@github.com/signalapp/libsignal-protocol-rust.git" }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,8 @@
+use std::env;
+
+fn main() {
+    if env::var("CARGO_CFG_TARGET_VENDOR").unwrap() == "apple" {
+        println!("cargo:rustc-cdylib-link-arg=-install_name");
+        println!("cargo:rustc-cdylib-link-arg=@rpath/libsignal_ffi.dylib");
+    }
+}


### PR DESCRIPTION
Install names determine how other projects find a library, and this library is intended to be embedded into an iOS app, so it must be found relative to *something*. `@rpath`-relative is the standard way to do this on Apple platforms.